### PR TITLE
Selenium browser using standalone docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,21 @@
-FROM node:12
-
-#USER root
-
-# Install latest stable Chrome
-# https://gerg.dev/2021/06/making-chromedriver-and-chrome-versions-match-in-a-docker-image/
-RUN echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | \
-    tee -a /etc/apt/sources.list.d/google.list && \
-    wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | \
-    apt-key add - && \
-    apt-get update && \
-    apt-get install -y google-chrome-stable libxss1
-
-# Determine major browser version
-ARG BROWSER_MAJOR=$(google-chrome --version | sed 's/Google Chrome \([0-9]*\).*/\1/g')
-
-# Install the Chromedriver version that corresponds to the installed major Chrome version
-# https://blogs.sap.com/2020/12/01/ui5-testing-how-to-handle-chromedriver-update-in-docker-image/
-RUN google-chrome --version | grep -oE "[0-9]{1,10}.[0-9]{1,10}.[0-9]{1,10}" > /tmp/chromebrowser-main-version.txt
-RUN wget --no-verbose -O /tmp/latest_chromedriver_version.txt https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$(cat /tmp/chromebrowser-main-version.txt)
-RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$(cat /tmp/latest_chromedriver_version.txt)/chromedriver_linux64.zip && rm -rf /opt/selenium/chromedriver && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium && rm /tmp/chromedriver_linux64.zip && mv /opt/selenium/chromedriver /opt/selenium/chromedriver-$(cat /tmp/latest_chromedriver_version.txt) && chmod 755 /opt/selenium/chromedriver-$(cat /tmp/latest_chromedriver_version.txt) && ln -fs /opt/selenium/chromedriver-$(cat /tmp/latest_chromedriver_version.txt) /usr/bin/chromedriver
-
-# Install dumb-init
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 && \
-  echo "37f2c1f0372a45554f1b89924fbb134fc24c3756efaedf11e07f599494e0eff9  /usr/local/bin/dumb-init" | sha256sum -c - && \
-  chmod 755 /usr/local/bin/dumb-init
-
-# Install xvfb for running in headful mode
-RUN apt-get update && apt-get install -yq xvfb
-
-# Install the app
-COPY . /app/
-WORKDIR app
+FROM mhart/alpine-node:12 AS build
+WORKDIR /app
+COPY package.json package-lock.json tsconfig.json ./
+COPY src ./src
 RUN npm install \
   && npm run build-ts \
   && npm prune --production
 
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 && \
+  echo "37f2c1f0372a45554f1b89924fbb134fc24c3756efaedf11e07f599494e0eff9  /usr/local/bin/dumb-init" | sha256sum -c - && \
+  chmod 755 /usr/local/bin/dumb-init
+
+# Only copy over the node pieces we need from the above image
+FROM mhart/alpine-node:slim-12 AS final
+WORKDIR /app
+COPY --from=build /usr/local/bin/dumb-init /usr/local/bin/dumb-init
+COPY --from=build /app .
+COPY . .
 EXPOSE 28866
 LABEL com.automatoninc.cog-for="Browser Selenium"
-ENTRYPOINT ["/usr/local/bin/dumb-init", "--", "xvfb-run", "--auto-servernum", "--server-num=1", "--server-args=-screen 0 1280x960x24", "node", "build/core/grpc-server.js"]
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--", "node", "build/core/grpc-server.js"]

--- a/examples/nav.yml
+++ b/examples/nav.yml
@@ -1,0 +1,9 @@
+scenario: Demonstrate the Web Cog
+description: Proves that this Cog works.
+
+steps:
+- step: First, navigate using selenium edge to http://go.automatoninc.com/dev-qa-email-confirmation.html
+- step: Then use selenium to fill out input[name=FirstName] with Atoma
+- step: And use selenium to fill out input[name=LastName] with Tommy
+- step: And use selenium to fill out input[name=Email] with atommy@example.com
+- step: Finally, use selenium to click the page element button[type=submit]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build-ts": "tsc",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "start": "check-engine package.json && ts-node src/core/grpc-server.ts",
+    "start-local-docker": "docker run -d -p 4444:4444 --shm-size=2g selenium/standalone-chrome && docker run -d -p 4445:4444 --shm-size=2g selenium/standalone-firefox && docker run -d -p 4446:4444 --shm-size=2g selenium/standalone-edge",
     "test": "nyc mocha -r ts-node/register test/*.ts test/**/*.ts test/**/**/*.ts",
     "version": "crank cog:readme automatoninc/web-selenium && git add README.md"
   },

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -12,7 +12,7 @@ class ClientWrapper {
   public clientReady: Promise<boolean>;
   public blobContainerClient: any;
 
-  constructor(client: any, auth: grpc.Metadata) {
+  constructor(client: any, auth: grpc.Metadata, idMap) {
     this.client = client;
   }
 }

--- a/src/client/mixins/basic-interaction.ts
+++ b/src/client/mixins/basic-interaction.ts
@@ -1,6 +1,6 @@
 import { Promise as Bluebird } from 'bluebird';
 import { keyCodes } from '../_shared/constants/key-codes.constant';
-import { WebDriver, By } from 'selenium-webdriver';
+import { WebDriver, By, until } from 'selenium-webdriver';
 
 export class BasicInteractionAware {
   // public client: Page;
@@ -10,14 +10,22 @@ export class BasicInteractionAware {
   public blobContainerClient: any;
 
   public async navigateToUrl(url: string, browser: string = 'chrome') {
-    return await this.client.get(url);
+    console.log('>>>>> inside navigateToUrl basic interaction');
+    console.timeLog('time');
+    const response = await this.client.get(url);
+    console.log('response', response);
+    console.log('>>>>> checkpoint: finished navigating to page or timed out');
+    console.timeLog('time');
+    return;
   }
 
   public async fillOutField(selector: string, value: any) {
+    await this.client.wait(until.elementLocated(By.css(selector)), 10000);
     return await this.client.findElement(By.css(selector)).sendKeys(value);
   }
 
   public async clickElement(selector: string) {
+    await this.client.wait(until.elementLocated(By.css(selector)), 10000);
     return await this.client.findElement(By.css(selector)).click();
   }
 

--- a/src/steps/click-on-element.ts
+++ b/src/steps/click-on-element.ts
@@ -1,11 +1,11 @@
 import { BaseStep, ExpectedRecord, Field, StepInterface } from '../core/base-step';
 import { Step, RunStepResponse, FieldDefinition, StepDefinition, StepRecord, RecordDefinition } from '../proto/cog_pb';
 
-export class ClickOnElement extends BaseStep implements StepInterface {
+export class SeleniumClickOnElement extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Click an element on a page';
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = 'click the page element (?<domQuerySelector>.+)';
+  protected stepExpression: string = 'use selenium to click the page element (?<domQuerySelector>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
   protected expectedFields: Field[] = [{
     field: 'domQuerySelector',
@@ -57,4 +57,4 @@ export class ClickOnElement extends BaseStep implements StepInterface {
 
 }
 
-export { ClickOnElement as Step };
+export { SeleniumClickOnElement as Step };

--- a/src/steps/fill-out-field.ts
+++ b/src/steps/fill-out-field.ts
@@ -1,11 +1,11 @@
 import { BaseStep, ExpectedRecord, Field, StepInterface } from '../core/base-step';
 import { Step, RunStepResponse, FieldDefinition, StepDefinition, StepRecord, RecordDefinition } from '../proto/cog_pb';
 
-export class EnterValueIntoField extends BaseStep implements StepInterface {
+export class SeleniumEnterValueIntoField extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Fill out a form field';
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = 'fill out (?<domQuerySelector>.+) with (?<value>.+)';
+  protected stepExpression: string = 'use selenium to fill out (?<domQuerySelector>.+) with (?<value>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
   protected expectedFields: Field[] = [{
     field: 'domQuerySelector',
@@ -68,4 +68,4 @@ export class EnterValueIntoField extends BaseStep implements StepInterface {
 
 }
 
-export { EnterValueIntoField as Step };
+export { SeleniumEnterValueIntoField as Step };

--- a/src/steps/navigate-to-page.ts
+++ b/src/steps/navigate-to-page.ts
@@ -1,11 +1,11 @@
 import { BaseStep, ExpectedRecord, Field, StepInterface } from '../core/base-step';
 import { Step, RunStepResponse, FieldDefinition, StepDefinition, StepRecord, RecordDefinition } from '../proto/cog_pb';
 
-export class NavigateToPage extends BaseStep implements StepInterface {
+export class SeleniumNavigateToPage extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Navigate to a webpage';
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = 'navigate to (?<webPageUrl>.+)';
+  protected stepExpression: string = 'navigate using selenium (?<browser>.+) to (?<webPageUrl>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
   protected expectedFields: Field[] = [{
     field: 'browser',
@@ -29,11 +29,16 @@ export class NavigateToPage extends BaseStep implements StepInterface {
   }];
 
   async executeStep(step: Step): Promise<RunStepResponse> {
+    console.log('>>>>> INSIDE NAVIGATE-TO-PAGE STEP');
     const stepData: any = step.getData().toJavaScript();
     const browser: string = stepData.browser;
     const url: string = stepData.webPageUrl;
     try {
+      console.time('time');
+      console.log('>>>>> STARTED TIMER FOR NAVIGATE-TO-PAGE STEP');
       await this.client.navigateToUrl(url, browser);
+      console.log('>>>>> checkpoint: finished navigating, ending timer');
+      console.timeEnd('time');
       return this.pass('Successfully navigated to %s', [url], []);
     } catch (e) {
       console.log(e);
@@ -61,4 +66,4 @@ export class NavigateToPage extends BaseStep implements StepInterface {
 
 }
 
-export { NavigateToPage as Step };
+export { SeleniumNavigateToPage as Step };


### PR DESCRIPTION
- Set up the selenium web driver to use standalone docker containers to run each browser.
- Reverted the Dockerfile back to the original version
- Browser sessions are started and ended in cog.ts
- To install the standalone browsers locally, use `npm run start-local-docker`