### PR TITLE
Add xpath and partialLinkText selectors to Focus on Frame step

### DIFF
--- a/src/client/mixins/basic-interaction.ts
+++ b/src/client/mixins/basic-interaction.ts
@@ -85,12 +85,12 @@ export class BasicInteractionAware {
     return await this.client.findElement(By[selectBy](selector)).click();
   }
 
-  public async focusFrame(domQuerySelector: string) {
+  public async focusFrame(domQuerySelector: string, selectBy: string = 'css') {
     if (domQuerySelector === 'main') {
       await this.client.switchTo().defaultContent();
     } else {
-      await this.client.wait(until.elementLocated(By.css(domQuerySelector)), 10000);
-      await this.client.switchTo().frame(this.client.findElement(By.css(domQuerySelector)));
+      await this.client.wait(until.elementLocated(By[selectBy](domQuerySelector)), 10000);
+      await this.client.switchTo().frame(this.client.findElement(By[selectBy](domQuerySelector)));
     }
   }
 

--- a/src/steps/focus-on-frame.ts
+++ b/src/steps/focus-on-frame.ts
@@ -10,6 +10,11 @@ export class SeleniumFocusOnFrame extends BaseStep implements StepInterface {
   protected actionList: string[] = ['interact'];
   protected targetObject: string = 'Focus on frame';
   protected expectedFields: Field[] = [{
+    field: 'selectBy',
+    type: FieldDefinition.Type.STRING,
+    description: 'Select by',
+    optionality: FieldDefinition.Optionality.OPTIONAL,
+  }, {
     field: 'domQuerySelector',
     type: FieldDefinition.Type.STRING,
     description: 'The iframe\'s DOM query selector, or "main" for the main frame',
@@ -17,10 +22,15 @@ export class SeleniumFocusOnFrame extends BaseStep implements StepInterface {
 
   async executeStep(step: Step): Promise<RunStepResponse> {
     const stepData: any = step.getData().toJavaScript();
+    const selectBy: string = stepData.selectBy || 'css';
     const iframeSelector: string = stepData.domQuerySelector;
 
+    if (selectBy && !['css', 'xpath', 'partialLinkText'].includes(selectBy)) {
+      return this.error('Unsupported selection strategy. Please use css, xpath, or partialLinkText', [], []);
+    }
+
     try {
-      await this.client.focusFrame(iframeSelector);
+      await this.client.focusFrame(iframeSelector, selectBy);
       const screenshot = await this.client.client.takeScreenshot();
       const binaryRecord = this.binary('screenshot', 'Screenshot', 'image/png', screenshot);
       const record = this.createRecord(iframeSelector);


### PR DESCRIPTION
Focus on Frame step can now be selected using css, xpath, or partialLinkText selectors.