### PR TITLE
Remove units from ScrollTo expected field

### DIFF
--- a/src/steps/scroll-to.ts
+++ b/src/steps/scroll-to.ts
@@ -13,11 +13,6 @@ export class SeleniumScrollTo extends BaseStep implements StepInterface {
     field: 'depth',
     type: FieldDefinition.Type.NUMERIC,
     description: 'Depth',
-  }, {
-    field: 'units',
-    type: FieldDefinition.Type.STRING,
-    optionality: FieldDefinition.Optionality.OPTIONAL,
-    description: '% or px',
   }];
 
   async executeStep(step: Step): Promise<RunStepResponse> {


### PR DESCRIPTION
Removing units from expected fields. It is still an optional field and defaults to %.